### PR TITLE
Apply replication by default

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -10,4 +10,12 @@ locals {
     Environment   = var.environment
     ManagedBy     = "terraform"
   }
+
+  default_parameters = [
+    {
+      name         = "rds.logical_replication"
+      value        = 1
+      apply_method = "pending-reboot"
+    }
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "rds" {
   parameter_group_use_name_prefix = var.parameter_group_use_name_prefix
   parameter_group_description     = var.parameter_group_description
   family                          = var.parameter_group_family
-  parameters                      = var.parameters
+  parameters                      = concat(local.default_parameters, var.parameters)
 
   create_db_option_group       = var.create_db_option_group
   option_group_name            = var.option_group_name


### PR DESCRIPTION
## Ticket [INFRA-503](https://linear.app/gudangada/issue/INFRA-503/set-logical-replication-to-true-in-our-rds-module)
- Apply logical replication by default.
- It should be fine to enable this and prevent the needs to reboot RDS when integrating with Olympus.